### PR TITLE
Update import statements

### DIFF
--- a/FSHingTrip.js
+++ b/FSHingTrip.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import path from "path";
-import fs from "fs-extra";
-import diff from "diff";
-import { execSync } from "child_process";
+const path = require("path")
+const fs = require("fs-extra")
+const diff = require("diff")
+const execSync = require("child_process").execSync;
 
 if (process.argv.length < 3) {
   console.log("Please specify the path to the input directory");

--- a/FSHingTrip.js
+++ b/FSHingTrip.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const path = require("path")
-const fs = require("fs-extra")
-const diff = require("diff")
+const path = require("path");
+const fs = require("fs-extra");
+const diff = require("diff");
 const execSync = require("child_process").execSync;
 
 if (process.argv.length < 3) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "author": "",
   "license": "ISC",
-  "type": "module",
   "dependencies": {
     "diff": "^4.0.2",
     "fs-extra": "^9.0.1"


### PR DESCRIPTION
Updates the `import` statements to use `require` in order to work with node 10.x.

From what I can tell in the documentation, it looks like support for this feature is still considered experimental in 12.x but is included by default (documentation [here](https://nodejs.org/docs/latest-v12.x/api/esm.html)). It is not included in 10.x by default and the `--experimental-modules` flag only seems to apply to `.mjs` files, not `.js` (documentation [here](https://nodejs.org/docs/latest-v10.x/api/esm.html)).